### PR TITLE
gitdb 4.0.12 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,40 +1,62 @@
-{% set version = "4.0.7" %}
+{% set name = "gitdb" %}
+{% set version = "4.0.12" %}
 
 package:
-  name: gitdb
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/g/gitdb/gitdb-{{ version }}.tar.gz
-  sha256: 96bf5c08b157a666fec41129e6d327235284cca4c81e92109260f353ba138005
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: True  # [py<37]
 
 requirements:
   host:
     - pip
-    - python >=3.4
+    - python
+    - wheel
+    - setuptools
   run:
-    - python >=3.4
-    - smmap >=3.0.1
+    - python
+    - smmap >=3.0.1,<6
+
+# Don`t want to copy additionally .idx fixtures files.
+{% set tests_to_skip = "test_base" %}
+{% set tests_to_skip = tests_to_skip + " or test_pack" %}
+{% set tests_to_skip = tests_to_skip + " or test_pack_entity" %}
+{% set tests_to_skip = tests_to_skip + " or test_pack_index" %}
+{% set tests_to_skip = tests_to_skip + " or test_decompress_reader_special_case" %}
 
 test:
-  requires:
-    - pip
-  commands:
-    - pip check
   imports:
     - gitdb
     - gitdb.db
+    - gitdb.utils
+    - gitdb.test
+  commands:
+    - pip check
+    - pytest --pyargs gitdb.test -k "not ({{ tests_to_skip }})"
+  requires:
+    - pip
+    - pytest
 
 about:
   home: https://github.com/gitpython-developers/gitdb
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE
   summary: Git Object Database
+  description: |
+    GitDB allows you to access bare git repositories for reading and writing. 
+    It aims at allowing full access to loose objects as well as packs with
+    performance and scalability in mind. It operates exclusively on streams,
+    allowing to handle large objects with a small memory footprint.
+  doc_url: https://gitdb.readthedocs.io
+  dev_url: https://github.com/gitpython-developers/gitdb
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
gitdb 4.0.12 

**Destination channel:** Defaults

### Links

- [PKG-8976]
- dev_url:        https://github.com/gitpython-developers/gitdb/tree/4.0.12
- conda_forge:    https://github.com/conda-forge/gitdb-feedstock
- pypi:           https://pypi.org/project/gitdb/4.0.12
- pypi inspector: https://inspector.pypi.io/project/gitdb/4.0.12

### Explanation of changes:

- new version number


[PKG-8976]: https://anaconda.atlassian.net/browse/PKG-8976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ